### PR TITLE
Clarify handling of .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,11 @@ current directory.
 
 ## How it works
 
-Before each prompt, direnv checks for the existence of a `.envrc` or `.env`
-file in the current and parent directories. If the file exists (and is
-authorized), it is loaded into a **bash** sub-shell and all exported
-variables are then captured by direnv and then made available to the current
-shell.
-
-If both `.envrc` and `.env` files exists, the `.envrc` will always be chosen
-first.
+Before each prompt, direnv checks for the existence of a `.envrc` file (and
+[optionally](man/direnv.toml.1.md#load_dotenv) a `.env` file) in the current
+and parent directories. If the file exists (and is authorized), it is loaded
+into a **bash** sub-shell and all exported variables are then captured by
+direnv and then made available to the current shell.
 
 It supports hooks for all the common shells like bash, zsh, tcsh and fish.
 This allows project-specific environment variables without cluttering the

--- a/internal/cmd/cmd_allow.go
+++ b/internal/cmd/cmd_allow.go
@@ -65,7 +65,10 @@ func cmdAllowAction(env Env, args []string, config *Config) (err error) {
 	if err != nil {
 		return err
 	} else if rc == nil {
-		return fmt.Errorf(".envrc or .env file not found")
+		if config.LoadDotenv {
+			return fmt.Errorf(".envrc or .env file not found")
+		}
+		return fmt.Errorf(".envrc file not found")
 	}
 	return rc.Allow()
 }

--- a/internal/cmd/cmd_deny.go
+++ b/internal/cmd/cmd_deny.go
@@ -35,7 +35,10 @@ func cmdDenyAction(env Env, args []string, config *Config) (err error) {
 	if err != nil {
 		return err
 	} else if rc == nil {
-		return fmt.Errorf(".envrc or .env file not found")
+		if config.LoadDotenv {
+			return fmt.Errorf(".envrc or .env file not found")
+		}
+		return fmt.Errorf(".envrc file not found")
 	}
 	return rc.Deny()
 }

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -54,7 +54,7 @@ If set to \fB\fCtrue\fR, stdin is disabled (redirected to /dev/null) during the 
 
 .SS \fB\fCload_dotenv\fR
 .PP
-Also look for and load \fB\fC\&.env\fR files on top of the \fB\fC\&.envrc\fR files.
+Also look for and load \fB\fC\&.env\fR files on top of the \fB\fC\&.envrc\fR files. If both \fB\fC\&.envrc\fR and \fB\fC\&.env\fR files exist, the \fB\fC\&.envrc\fR will always be chosen first.
 
 .SS \fB\fCstrict_env\fR
 .PP

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -44,7 +44,7 @@ If set to `true`, stdin is disabled (redirected to /dev/null) during the `.envrc
 
 ### `load_dotenv`
 
-Also look for and load `.env` files on top of the `.envrc` files.
+Also look for and load `.env` files on top of the `.envrc` files. If both `.envrc` and `.env` files exist, the `.envrc` will always be chosen first.
 
 ### `strict_env`
 


### PR DESCRIPTION
Follow-up on https://github.com/direnv/direnv/pull/845 and https://github.com/direnv/direnv/pull/911: resolves https://github.com/direnv/direnv/issues/916

This PR simply updates the error messages and documentation to more accurately reflect the current opt-in configurable handling of `.env` files.